### PR TITLE
feat: added mime type to returned file ref and node

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ except S3Error as e:
     print(e)
 ```
 
+Available methods:
+
+* `upload_file`: Upload a file provided by FastAPI to S3.
+* `upload_local_file`: Upload a local file to S3.
+* `get_file`: Get a file content from S3.
+* `list_files`: List files from a "folder" in S3.
+* `path_exists`: Check if a file exists in S3.
+* `copy_file`: Copy a file in S3.
+* `move_file`: Move a file in S3.
+* `delete_file`: Delete a file in S3.
+
+
 ### FileChecker
 
 ```python
@@ -47,7 +59,7 @@ file_checker = FileChecker()
 # Example usage with FastAPI
 @router.post("/tmp",
              status_code=200,
-             description="Upload any assets to S3",
+             description="Upload any assets to S3 to a temporary folder",
              dependencies=[Depends(file_checker.check_size)])
 async def upload_temp_files(
         files: list[UploadFile] = File(description="multiple file upload")):

--- a/enacit4r_files/models/files.py
+++ b/enacit4r_files/models/files.py
@@ -5,17 +5,21 @@ class FileRef(BaseModel):
   name: str
   path: str
   size: int
+  mime_type: Optional[str] = None
   alt_name: Optional[str] = None
   alt_path: Optional[str] = None
   alt_size: Optional[int] = None
+  alt_mime_type: Optional[str] = None
   
 class FileNode(BaseModel):
   name: str
   path: Optional[str] = None
   size: Optional[int] = None
+  mime_type: Optional[str] = None
   alt_name: Optional[str] = None
   alt_path: Optional[str] = None
   alt_size: Optional[int] = None
+  alt_mime_type: Optional[str] = None
   is_file: bool
   children: Optional[List["FileNode"]] = Field(default_factory=list)
   

--- a/enacit4r_files/utils/files.py
+++ b/enacit4r_files/utils/files.py
@@ -111,11 +111,13 @@ class FileNodeBuilder:
                 if not is_file:
                     new_path = file_ref.path.split(new_path)[0] + new_path
                 new_size = file_ref.size if is_file else None
-                new_node = FileNode(name = part, path = new_path, size = new_size, is_file = is_file)
+                new_mime_type = file_ref.mime_type if is_file else None
+                new_node = FileNode(name = part, path = new_path, size = new_size, mime_type=new_mime_type, is_file = is_file)
                 if is_file and file_ref.alt_name:
                     new_node.alt_name = file_ref.alt_name
                     new_node.alt_path = file_ref.alt_path
                     new_node.alt_size = file_ref.alt_size
+                    new_node.alt_mime_type = file_ref.alt_mime_type
                 current_node.children.append(new_node)
                 current_node = new_node
             else:


### PR DESCRIPTION
Include mime type in the returned s3 file reference object, so that client application can more easily handle attached files per type (e.g. display image or video, download link to pdf etc.).